### PR TITLE
Drop extra VC [skip ci]

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,14 +23,6 @@ environment:
       CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35
-
-    - TARGET_ARCH: x64
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
-
-    - TARGET_ARCH: x86
       CONDA_PY: 36
       CONDA_INSTALL_LOCN: C:\\Miniconda35
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,21 +17,21 @@ source:
 build:
   number: 4
   features:
-    - vc9  # [win and py27]
+    - vc9   # [win and py27]
     - vc10  # [win and py34]
     - vc14  # [win and py35]
 
 requirements:
   build:
     - python  # [win]
-    - cmake  # [win]
-    - vc 9  # [win and py27]
-    - vc 10  # [win and py34]
-    - vc 14  # [win and py35]
+    - cmake   # [win]
+    - vc 9    # [win and py27]
+    - vc 10   # [win and py34]
+    - vc 14   # [win and py35]
   run:
-    - vc 9  # [win and py27]
-    - vc 10  # [win and py34]
-    - vc 14  # [win and py35]
+    - vc 9    # [win and py27]
+    - vc 10   # [win and py34]
+    - vc 14   # [win and py35]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ source:
 
 build:
   number: 4
+  skip: true  # [win and py35]
   features:
     - vc9   # [win and py27]
     - vc10  # [win and py34]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ build:
     - vc9   # [win and py27]
     - vc10  # [win and py34]
     - vc14  # [win and py35]
+    - vc14  # [win and py36]
 
 requirements:
   build:
@@ -28,10 +29,12 @@ requirements:
     - vc 9    # [win and py27]
     - vc 10   # [win and py34]
     - vc 14   # [win and py35]
+    - vc 14   # [win and py36]
   run:
     - vc 9    # [win and py27]
     - vc 10   # [win and py34]
     - vc 14   # [win and py35]
+    - vc 14   # [win and py36]
 
 test:
   commands:


### PR DESCRIPTION
Both Python 3.5 and 3.6 make use of VC 14. So drop Python 3.5 and stick with Python 3.6.