### PR TITLE
Skip Windows Python 3.5 (instead of Python 3.6)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [win and py36]
+  skip: true  # [win and py35]
   features:
     - vc9   # [win and py27]
     - vc14  # [win and (py35 or py36)]


### PR DESCRIPTION
Should have the same effect in terms of packages generated. Though it fixes an issue where Python 3.5 was not deploying, but Python 3.6 would deploy.