### PR TITLE
Windows: ensure ABI compatibility

### DIFF
--- a/recipe/CMakeLists.txt.patch
+++ b/recipe/CMakeLists.txt.patch
@@ -1,6 +1,6 @@
 --- /dev/null
 +++ CMakeLists.txt
-@@ -0,0 +1,64 @@
+@@ -0,0 +1,66 @@
 +# Copyright (C) 2007-2012 LuaDist.
 +# Created by Peter Drahoš
 +# Redistribution and use of this file is allowed according to the terms of the MIT license.
@@ -22,7 +22,7 @@
 +
 +configure_file(config.h.cmake ${CMAKE_CURRENT_SOURCE_DIR}/config.h)
 +configure_file(include/iconv.h.build.in ${CMAKE_CURRENT_SOURCE_DIR}/include/iconv.h)
-+configure_file(libcharset/include/libcharset.h.in ${CMAKE_CURRENT_SOURCE_DIR}/include/libcharset.h)
++configure_file(libcharset/include/libcharset.h.build.in ${CMAKE_CURRENT_SOURCE_DIR}/include/libcharset.h)
 +configure_file(srclib/uniwidth.in.h ${CMAKE_CURRENT_SOURCE_DIR}/srclib/uniwidth.h)
 +configure_file(srclib/unitypes.in.h ${CMAKE_CURRENT_SOURCE_DIR}/srclib/unitypes.h)
 +
@@ -38,6 +38,7 @@
 +# libcharset
 +set(SRC_LIBCHARSET
 +  libcharset/lib/localcharset.c
++  libcharset/lib/relocatable-stub.c
 +)
 +
 +add_library(charset SHARED ${SRC_LIBCHARSET})
@@ -47,6 +48,7 @@
 +# libiconv
 +set(SRC_LIBICONV
 +  lib/iconv.c
++  lib/compat.c
 +)
 +
 +add_library(iconv SHARED ${SRC_LIBICONV})

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,8 @@ outputs:
 
     test:
       requires:
-        - jq  # [unix]
+        - jq          # [unix]
+        - pkg-config  # [win]
       commands:
         # Ensuring iconv executable is not present.
         # Otherwise the included license is wrong and should be GPL-3.0-only.
@@ -73,6 +74,8 @@ outputs:
         - if not exist %LIBRARY_PREFIX%\lib\charset.lib exit 1  # [win]
         - if not exist %LIBRARY_PREFIX%\bin\iconv.dll exit 1    # [win]
         - if not exist %LIBRARY_PREFIX%\bin\charset.dll exit 1  # [win]
+        # Regression test for https://github.com/conda-forge/libiconv-feedstock/issues/48
+        - pkg-config --help  # [win]
     about:
       home: https://www.gnu.org/software/libiconv/
       license: LGPL-2.1-only

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - utf_8_mac.patch  # [osx]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
The `libcharset_set_relocation_prefix` and `libiconv_set_relocation_prefix` stubs were missing on Windows.

Resolves: #48.
Regressed since: #47.